### PR TITLE
Use a function to derive the node_id

### DIFF
--- a/lib/hlclock.ex
+++ b/lib/hlclock.ex
@@ -66,12 +66,14 @@ defmodule HLClock do
 
   ## Example
 
-      iex> {:ok, t0} = Timestamp.new(1410652800000, 0, 0)
+      iex> {:ok, _t0} = HLClock.Timestamp.new(1410652800000, 0, 0)
       {:ok, %HLClock.Timestamp{counter: 0, node_id: 0, time: 1410652800000}}
-      iex> encoded = Timestamp.encode(t0)
+
+      ...> encoded = HLClock.Timestamp.encode(t0)
       <<1, 72, 113, 117, 132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
-      iex> << time_and_counter :: size(64), _ :: size(64) >> = encoded
-      iex> DateTime.from_unix(time_and_counter, :microsecond)
+      ...> << time_and_counter :: size(64), _ :: size(64) >> = encoded
+
+      ...> DateTime.from_unix(time_and_counter, :microsecond)
       {:ok, #DateTime<4899-07-30 06:31:40.800000Z>}
   """
   def to_datetime(%Timestamp{time: t}) do
@@ -100,7 +102,11 @@ defmodule HLClock do
   end
 
   defp build_opts(opts) do
-    opts
-    |> Keyword.put_new(:node_id, NodeId.hash())
+    base_opts()
+    |> Keyword.merge(opts)
   end
+
+  defp base_opts, do: [
+    node_id: Application.get_env(:hlclock, :node_id, fn -> NodeId.hash() end)
+  ]
 end

--- a/lib/hlclock/server.ex
+++ b/lib/hlclock/server.ex
@@ -8,7 +8,7 @@ defmodule HLClock.Server do
   end
 
   def init(opts) do
-    Timestamp.new(physical_time(), default_counter(), opts[:node_id])
+    Timestamp.new(physical_time(), default_counter(), node_id(opts))
   end
 
   def handle_call(:send_timestamp, _from, timestamp) do
@@ -32,4 +32,6 @@ defmodule HLClock.Server do
   defp physical_time, do: System.os_time(:milliseconds)
 
   defp default_counter, do: 0
+
+  defp node_id([{:node_id, fun} | _]) when is_function(fun), do: fun.()
 end

--- a/test/hlclock_test.exs
+++ b/test/hlclock_test.exs
@@ -1,11 +1,21 @@
 defmodule HLClockTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+  doctest HLClock
 
   describe "node names" do
     test "HLClocks can be given a node id" do
-      {:ok, _hlc} = HLClock.start_link(node_id: 12345)
+      node_id = fn -> 12345 end
+      {:ok, _hlc} = HLClock.start_link(node_id: node_id)
       {:ok, clock} = HLClock.send_timestamp()
       assert %{node_id: 12345} = clock
+    end
+
+    test "can be added in a config" do
+      Application.put_env(:hlclock, :node_id, fn -> 1337 end)
+      {:ok, _hlc} = HLClock.start_link()
+      {:ok, clock} = HLClock.send_timestamp()
+      Application.delete_env(:hlclock, :node_id)
+      assert %{node_id: 1337} = clock
     end
 
     test "if no node id is given then we use a hash of the node name" do


### PR DESCRIPTION
This is some pre-refactoring in preparation for the improvements to the OTP application.